### PR TITLE
Mobile content centering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -116,6 +116,17 @@ i {
     cursor: pointer
 }
 
+/* Mobile overrides */
+@media (max-width: 600px) {
+    body {
+        text-align: center
+    }
+
+    .right-side .block {
+        margin-left: 0px
+    }
+}
+
 /* Dark Mode overrides */
 @media (prefers-color-scheme: dark) {
     body {

--- a/index.html
+++ b/index.html
@@ -56,14 +56,14 @@
             </div>
             <hr>
             <div class="block">
-              <h5 class="left-align"><i class="mdi-action-account-box"></i>About me</h5>
+              <h5><i class="mdi-action-account-box"></i>About me</h5>
               <p>
                 Super into Ruby, music, coffee, tea, beer, longboarding,
                 ultimate frisbee, gaming, and Japanese language and culture.
               </p>
             </div>
             <div class="block">
-              <h5 class="left-align"><i class="mdi-action-perm-phone-msg"></i>Contact me</h5>
+              <h5><i class="mdi-action-perm-phone-msg"></i>Contact me</h5>
               <p>
                 <i class="mdi-maps-pin-drop orange-text darken-1"></i>
                 <a href="https://goo.gl/maps/MtDzzmAWjqR2">Tokyo, Japan</a><br>


### PR DESCRIPTION
Content should be centered when viewed on mobile but remain left aligned on larger screens.

🎩 Desktop, mobile (portrait), mobile (landscape)
<img width="1440" alt="Screen Shot 2019-12-29 at 11 34 46" src="https://user-images.githubusercontent.com/1557529/71559695-5a989500-2a2f-11ea-95dd-ce5714841055.png">
<img width="1440" alt="Screen Shot 2019-12-29 at 11 34 59" src="https://user-images.githubusercontent.com/1557529/71559696-5a989500-2a2f-11ea-8f89-2bbf9cc1ecbd.png">
<img width="1440" alt="Screen Shot 2019-12-29 at 11 35 33" src="https://user-images.githubusercontent.com/1557529/71559697-5a989500-2a2f-11ea-8510-c15286fa1377.png">