### PR TITLE
Light/dark topbar with Safari support

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,9 @@
   sizes="114x114">
 
   <!-- Topbar colour -->
-  <!-- Chrome, Firefox OS and Opera -->
-  <meta name="theme-color" content="#46E4F7">
+  <!-- Chrome, Firefox, Opera, and macOS Safari -->
+  <meta name="theme-color" content="#46E4F7" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
   <!-- Windows Phone -->
   <meta name="msapplication-navbutton-color" content="#46E4F7">
   <!-- iOS Safari -->

--- a/uses/index.html
+++ b/uses/index.html
@@ -18,8 +18,9 @@
   <link href="../assets/images/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114">
 
   <!-- Topbar colour -->
-  <!-- Chrome, Firefox OS and Opera -->
-  <meta name="theme-color" content="#46E4F7">
+  <!-- Chrome, Firefox, Opera, and macOS Safari -->
+  <meta name="theme-color" content="#46E4F7" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
   <!-- Windows Phone -->
   <meta name="msapplication-navbutton-color" content="#46E4F7">
   <!-- iOS Safari -->


### PR DESCRIPTION
Safari 15 added support for topbar colours with light/dark mode specification. 🙌 

Before (grey in dark mode)
<img width="1390" alt="Screen Shot 2021-10-04 at 10 47 03" src="https://user-images.githubusercontent.com/1557529/135782298-4271ac2c-2552-4104-8329-313262ce7014.png">
<img width="1390" alt="Screen Shot 2021-10-04 at 10 47 10" src="https://user-images.githubusercontent.com/1557529/135782309-ed5bb859-f4df-471e-a420-665c87e37d46.png">

After (this change)
<img width="1390" alt="Screen Shot 2021-10-04 at 10 44 05" src="https://user-images.githubusercontent.com/1557529/135782241-fc107493-6e65-47f5-83b6-6c33f628590d.png">
<img width="1390" alt="Screen Shot 2021-10-04 at 10 44 10" src="https://user-images.githubusercontent.com/1557529/135782246-48b74d42-c7ae-40b9-b205-0b11cf8786cb.png">
