### PR TITLE
Move FLOSS.social rel=me link to head

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
   <link href="assets/images/apple-touch-icon-114x114.png" rel="apple-touch-icon"
   sizes="114x114">
 
+  <!-- FLOSS.social Mastodon rel me link -->
+  <link href="https://floss.social/@larouxn" rel="me">
+
   <!-- Topbar colour -->
   <!-- Chrome, Firefox, Opera, and macOS Safari -->
   <meta name="theme-color" content="#46E4F7" media="(prefers-color-scheme: light)">
@@ -69,9 +72,6 @@
               </p>
               <p>
                 Super into Ruby, Linux, open source, music, coffee, beer, longboarding, and ultimate frisbee.
-              </p>
-              <p>
-                <a rel="me" href="https://floss.social/@larouxn">@larouxn (FLOSS.social) 🐘</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Don't need an obvious public facing link.